### PR TITLE
Add PyPI distribution infrastructure (pydqm)

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -83,6 +83,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install OpenMP (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
       - name: Download wheels
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,99 @@
+name: Build wheels
+
+on:
+  push:
+    branches: [main, feature/pip-install]
+  pull_request:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14]
+        # macos-13 is Intel, macos-14 is Apple Silicon
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install OpenMP (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libomp
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.21
+        env:
+          # Build for Python 3.9-3.12
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          # Skip 32-bit builds and musllinux (to keep build times reasonable)
+          CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
+          # Install OpenMP on Linux before building
+          CIBW_BEFORE_ALL_LINUX: yum install -y libgomp || apt-get update && apt-get install -y libgomp1
+          # Test that the wheel works
+          CIBW_TEST_COMMAND: python -c "import dqm; print('dqm_lib loaded:', dqm.dqm_lib is not None)"
+          CIBW_TEST_REQUIRES: numpy
+          # macOS deployment target
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  test:
+    name: Test on ${{ matrix.os }} / Python ${{ matrix.python-version }}
+    needs: [build_wheels]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: wheelhouse
+
+      - name: Install wheel
+        run: |
+          pip install numpy
+          pip install --find-links wheelhouse dqm
+
+      - name: Run basic import test
+        run: python -c "import dqm; print('dqm_lib loaded:', dqm.dqm_lib is not None)"
+
+      - name: Run package tests
+        run: |
+          cd /tmp  # Run from different directory to ensure installed package is used
+          python -m unittest dqm.DQMTests -v

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,6 +8,7 @@ on:
   release:
     types: [published]
   workflow_dispatch:  # Allow manual trigger
+  workflow_call:  # Allow being called by other workflows
 
 jobs:
   build_wheels:
@@ -88,7 +89,7 @@ jobs:
       - name: Install wheel
         run: |
           pip install numpy
-          pip install --find-links wheelhouse dqm
+          pip install --find-links wheelhouse pydqm
 
       - name: Run basic import test
         run: python -c "import dqm; print('dqm_lib loaded:', dqm.dqm_lib is not None)"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -17,8 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
-        # macos-13 is Intel, macos-14 is Apple Silicon
+        os: [ubuntu-latest, macos-latest]
+        # macos-latest is Apple Silicon (arm64)
+        # Note: Intel Mac builds removed - macos-13 retired, macos-15-intel not yet stable
 
     steps:
       - uses: actions/checkout@v4
@@ -30,17 +31,20 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          # Build for Python 3.9-3.12
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          # Build for Python 3.10-3.12 (3.9 dropped for simpler compatibility)
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           # Skip 32-bit builds and musllinux (to keep build times reasonable)
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
-          # Install OpenMP on Linux before building
-          CIBW_BEFORE_ALL_LINUX: yum install -y libgomp || apt-get update && apt-get install -y libgomp1
           # Test that the wheel works
           CIBW_TEST_COMMAND: python -c "import dqm; print('dqm_lib loaded:', dqm.dqm_lib is not None)"
           CIBW_TEST_REQUIRES: numpy
-          # macOS deployment target
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
+          # macOS: use delocate but exclude OpenMP (users need brew install libomp)
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            delocate-wheel --require-archs {delocate_archs}
+            --exclude libomp.dylib
+            -w {dest_dir} -v {wheel}
+          # macOS deployment target (11.0 minimum for arm64)
+          CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=11.0
 
       - uses: actions/upload-artifact@v4
         with:
@@ -69,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -2,7 +2,7 @@ name: Build wheels
 
 on:
   push:
-    branches: [main, feature/pip-install]
+    branches: [main]
   pull_request:
     branches: [main]
   release:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          # Build for Python 3.10-3.12 (3.9 dropped for simpler compatibility)
+          # Build for Python 3.10-3.13
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           # Skip 32-bit builds and musllinux (to keep build times reasonable)
           CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
     name: Build wheels
     uses: ./.github/workflows/build-wheels.yml
 
+  # TODO: Remove this job if TestPyPI is never needed
   publish-testpypi:
     name: Publish to TestPyPI
     needs: [build]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,26 +106,7 @@ jobs:
       - name: List artifacts
         run: ls -la dist/
 
-      # Uncomment after setting up PyPI trusted publishing
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     packages-dir: dist/
-
-      - name: PyPI placeholder
-        run: |
-          echo "============================================="
-          echo "PyPI publishing is not yet configured."
-          echo ""
-          echo "To enable:"
-          echo "1. Create account at https://pypi.org"
-          echo "2. Add trusted publisher at https://pypi.org/manage/account/publishing/"
-          echo "   - Project: pydqm"
-          echo "   - Owner: zanderteller"
-          echo "   - Repo: dqm"
-          echo "   - Workflow: publish.yml"
-          echo "   - Environment: pypi"
-          echo "3. Create 'pypi' environment in GitHub repo settings"
-          echo "4. Uncomment the publish step above"
-          echo "============================================="
-          ls -la dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:  # Allow manual trigger for testing
+
+jobs:
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    # Only run on releases from the main repo (not forks)
+    if: github.repository == 'zanderteller/dqm'
+
+    # IMPORTANT: Configure trusted publishing in PyPI before enabling this
+    # See: https://docs.pypi.org/trusted-publishers/
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pydqm
+
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      # Uncomment the following step after setting up PyPI trusted publishing
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     # No password needed with trusted publishing
+      #     packages-dir: dist/
+
+      - name: Publication placeholder
+        run: |
+          echo "============================================="
+          echo "PyPI publishing is not yet configured."
+          echo ""
+          echo "To enable publishing:"
+          echo "1. Register 'pydqm' package on PyPI"
+          echo "2. Set up trusted publishing for this repo"
+          echo "3. Uncomment the publish step in this workflow"
+          echo "============================================="
+          echo ""
+          echo "Artifacts that would be published:"
+          ls -la dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,51 +3,129 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  workflow_dispatch:  # Allow manual trigger for testing
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Publish target'
+        required: true
+        default: 'testpypi'
+        type: choice
+        options:
+          - testpypi
+          - pypi
 
 jobs:
-  publish:
-    name: Publish to PyPI
-    runs-on: ubuntu-latest
-    # Only run on releases from the main repo (not forks)
-    if: github.repository == 'zanderteller/dqm'
+  build:
+    name: Build wheels
+    uses: ./.github/workflows/build-wheels.yml
 
-    # IMPORTANT: Configure trusted publishing in PyPI before enabling this
-    # See: https://docs.pypi.org/trusted-publishers/
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+
     environment:
-      name: pypi
-      url: https://pypi.org/p/pydqm
+      name: testpypi
+      url: https://test.pypi.org/p/pydqm
 
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write
 
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          path: dist
+          pattern: wheels-*
           merge-multiple: true
+          path: dist
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
 
       - name: List artifacts
         run: ls -la dist/
 
-      # Uncomment the following step after setting up PyPI trusted publishing
+      # Uncomment after setting up TestPyPI trusted publishing
+      # - name: Publish to TestPyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     repository-url: https://test.pypi.org/legacy/
+      #     packages-dir: dist/
+
+      - name: TestPyPI placeholder
+        run: |
+          echo "============================================="
+          echo "TestPyPI publishing is not yet configured."
+          echo ""
+          echo "To enable:"
+          echo "1. Create account at https://test.pypi.org"
+          echo "2. Add trusted publisher at https://test.pypi.org/manage/account/publishing/"
+          echo "   - Project: pydqm"
+          echo "   - Owner: zanderteller"
+          echo "   - Repo: dqm"
+          echo "   - Workflow: publish.yml"
+          echo "   - Environment: testpypi"
+          echo "3. Create 'testpypi' environment in GitHub repo settings"
+          echo "4. Uncomment the publish step above"
+          echo "============================================="
+          ls -la dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'release') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pydqm
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      # Uncomment after setting up PyPI trusted publishing
       # - name: Publish to PyPI
       #   uses: pypa/gh-action-pypi-publish@release/v1
       #   with:
-      #     # No password needed with trusted publishing
       #     packages-dir: dist/
 
-      - name: Publication placeholder
+      - name: PyPI placeholder
         run: |
           echo "============================================="
           echo "PyPI publishing is not yet configured."
           echo ""
-          echo "To enable publishing:"
-          echo "1. Register 'pydqm' package on PyPI"
-          echo "2. Set up trusted publishing for this repo"
-          echo "3. Uncomment the publish step in this workflow"
+          echo "To enable:"
+          echo "1. Create account at https://pypi.org"
+          echo "2. Add trusted publisher at https://pypi.org/manage/account/publishing/"
+          echo "   - Project: pydqm"
+          echo "   - Owner: zanderteller"
+          echo "   - Repo: dqm"
+          echo "   - Workflow: publish.yml"
+          echo "   - Environment: pypi"
+          echo "3. Create 'pypi' environment in GitHub repo settings"
+          echo "4. Uncomment the publish step above"
           echo "============================================="
-          echo ""
-          echo "Artifacts that would be published:"
           ls -la dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vs/
 vs_tmp/
 build/
+dist/
 dqm.egg-info/
 *.pyc
 *.o

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,24 @@ DQM works on any given data set, using the mathematical framework of quantum mec
 
 No assumptions are made about the underlying structure of the data.
 
-Visual and numerical analysis of the resulting animated ‘evolution’ of the data can reveal both clusters and extended structures, leading to a rich understanding of relationships between and within different subsets of the data.
+Visual and numerical analysis of the resulting animated 'evolution' of the data can reveal both clusters and extended structures, leading to a rich understanding of relationships between and within different subsets of the data.
+
+Installation
+------------
+
+Install DQM using pip:
+
+.. code-block:: console
+
+   $ pip install pydqm
+
+For visualization support (recommended):
+
+.. code-block:: console
+
+   $ pip install pydqm[viz]
+
+See the `Installation Guide <https://dqm.readthedocs.io/en/latest/installation.html>`_ for more details.
 
 Documentation (on Read the Docs)
 --------------------------------

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.17)
+project(dqm_python LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Source files
+set(SOURCES
+    utils.cpp
+    array3d.cpp
+    basis.cpp
+    trajectories.cpp
+    operators.cpp
+    dqm_python.cpp
+)
+
+# Create shared library
+add_library(dqm_python SHARED ${SOURCES})
+
+# Remove the "lib" prefix that CMake adds by default on Unix
+set_target_properties(dqm_python PROPERTIES PREFIX "")
+
+# Include directories (Eigen is header-only, bundled in include/)
+target_include_directories(dqm_python PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Find OpenMP - try multiple approaches for macOS compatibility
+find_package(OpenMP)
+
+if(NOT OpenMP_CXX_FOUND AND APPLE)
+    # Try to find Homebrew's libomp on macOS
+    execute_process(
+        COMMAND brew --prefix libomp
+        OUTPUT_VARIABLE HOMEBREW_LIBOMP_PREFIX
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE BREW_RESULT
+    )
+    if(BREW_RESULT EQUAL 0 AND HOMEBREW_LIBOMP_PREFIX)
+        message(STATUS "Found Homebrew libomp at: ${HOMEBREW_LIBOMP_PREFIX}")
+        set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp" CACHE STRING "" FORCE)
+        set(OpenMP_CXX_LIB_NAMES "omp" CACHE STRING "" FORCE)
+        set(OpenMP_omp_LIBRARY "${HOMEBREW_LIBOMP_PREFIX}/lib/libomp.dylib" CACHE STRING "" FORCE)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${HOMEBREW_LIBOMP_PREFIX}/include")
+        find_package(OpenMP)
+    endif()
+endif()
+
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(dqm_python PRIVATE OpenMP::OpenMP_CXX)
+    message(STATUS "OpenMP enabled: ${OpenMP_CXX_FLAGS}")
+else()
+    message(WARNING "OpenMP not found. Building without OpenMP support (performance will be reduced).")
+endif()
+
+# Platform-specific settings
+if(APPLE)
+    set_target_properties(dqm_python PROPERTIES
+        SUFFIX ".dylib"
+        INSTALL_RPATH "@loader_path"
+    )
+elseif(UNIX)
+    set_target_properties(dqm_python PROPERTIES
+        SUFFIX ".so"
+    )
+endif()
+
+# Release build optimizations (when not in debug mode)
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(dqm_python PRIVATE -O2 -DNDEBUG)
+    # Note: -flto can cause issues on some platforms, omit for broader compatibility
+endif()
+
+# Install the library to the dqm/bin directory within the wheel
+# scikit-build-core will use this install target
+install(TARGETS dqm_python
+    LIBRARY DESTINATION dqm/bin
+    RUNTIME DESTINATION dqm/bin
+)

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -10,9 +10,11 @@ ifeq ($(OS),Darwin)
 # Mac OS
 CXX:=g++
 DLL=dylib
-OPENMPFLAGS:=-I/usr/local/include -Xpreprocessor -fopenmp
-OPENMPLIB:=-L/usr/local/lib -I/usr/local/include -lomp
-else 
+# Auto-detect Homebrew libomp location (works for both Intel and Apple Silicon)
+LIBOMP_PREFIX:=$(shell brew --prefix libomp 2>/dev/null || echo /usr/local)
+OPENMPFLAGS:=-I$(LIBOMP_PREFIX)/include -Xpreprocessor -fopenmp
+OPENMPLIB:=-L$(LIBOMP_PREFIX)/lib -lomp
+else
 # Linux
 DLL=so
 OPENMPFLAGS:=-Xpreprocessor -fopenmp

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,6 +14,8 @@ That's it! The package includes pre-compiled binaries, so no compiler is needed.
 
 **Requirements:** Python 3.10 or later. The only required dependency (numpy) is installed automatically.
 
+**Supported platforms:** Linux (x86_64), macOS (Apple Silicon). Intel Mac users should build from source (see Development Installation below).
+
 **macOS users:** You also need OpenMP installed:
 
 .. code-block:: console

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,7 +45,7 @@ To verify that DQM is installed correctly and the compiled library is working:
 .. code-block:: python
 
    import dqm
-   print("DQM version:", dqm.__version__ if hasattr(dqm, '__version__') else "0.1.0")
+   print("DQM version:", dqm.__version__)
    print("Compiled library loaded:", dqm.dqm_lib is not None)
 
 You should see ``Compiled library loaded: True``. If you see ``False``, the compiled library failed to load - please report this as an issue.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,13 @@ Install DQM using pip:
 
 That's it! The package includes pre-compiled binaries, so no compiler is needed.
 
-**Requirements:** Python 3.9 or later. The only required dependency (numpy) is installed automatically.
+**Requirements:** Python 3.10 or later. The only required dependency (numpy) is installed automatically.
+
+**macOS users:** You also need OpenMP installed:
+
+.. code-block:: console
+
+   $ brew install libomp
 
 Optional Dependencies
 ---------------------
@@ -134,13 +140,15 @@ The compiled library failed to load. This can happen if:
 
 Try installing from source (see Development Installation above).
 
-**Import errors on macOS**
+**macOS: "Library not loaded: libomp.dylib" or similar**
 
-If you see errors about ``libomp.dylib`` not found, install OpenMP:
+DQM uses OpenMP for parallel processing. On macOS, install it via Homebrew:
 
 .. code-block:: console
 
    $ brew install libomp
+
+Note: Homebrew will show a "keg-only" warning - this is normal and does not affect DQM.
 
 **Reporting Issues**
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,117 +1,147 @@
 Installation
 ============
 
-An 'official' Python release of DQM (via pip, conda, etc.) is not yet implemented. We've tried to make manual installation as easy as possible.
+Standard Installation
+---------------------
 
-Please report any issues on the DQM GitHub `Issues <https://github.com/zanderteller/dqm/issues>`_ page. (Or start on the DQM GitHub `Discussions <https://github.com/zanderteller/dqm/discussions>`_ page if you're not sure how to report the issue, whether the issue is really specific to DQM, etc.)
-
-Python Dependencies
--------------------
-
-You'll need to install some python packages that DQM expects to find. (You can install via pip, conda, etc., as you prefer.)
-
-Hard Dependencies
-^^^^^^^^^^^^^^^^^
-
-*These packages are required: DQM won't work without them.*
-
-* numpy
-
-Soft Dependencies
-^^^^^^^^^^^^^^^^^
-
-*The core functionality of DQM does not need any of these packages, but working with DQM will be much easier with them.*
-
-* jupyterlab (for working with DQM's example Jupyter notebooks)
-* plotly (for interactive animated 3D plotting)
-* matplotlib (for basic plotting)
-
-Cloning the DQM Repository
---------------------------
-
-Go to the `DQM GitHub <https://github.com/zanderteller/dqm>`_ page and clone the repository to your machine. (Use the green 'Code' button at top right of the page.)
-
-For right now, you probably want the 'main' branch, which is the default on the GitHub page. (There is a tagged version 0.1.0, but things may change quickly at first...)
-
-Setting Your PYTHONPATH
------------------------
-
-Wherever you put your local clone on your machine, the clone's top-level main folder (containing the README file), which we'll call ``<your clone main folder>``, will ultimately need to be in your PYTHONPATH.
-
-If you use pip generally to install packages, you can copy the DQM package to your 'standard' site-package location as shown below. (**NOTE:** be sure to do this *AFTER* building the compiled C++ library file.)
+Install DQM using pip:
 
 .. code-block:: console
 
-   $ cd <your clone main folder>
-   $ pip install .
+   $ pip install pydqm
 
-Compiling the C++ Library Code
-------------------------------
+That's it! The package includes pre-compiled binaries, so no compiler is needed.
 
-Important core functions in DQM are implemented in C++, which you'll need to compile on your machine. (*DQM has Python-only implementations of all of these core functions, but the Python versions will be unusably slow for all but the smallest data sets.*)
+**Requirements:** Python 3.9 or later. The only required dependency (numpy) is installed automatically.
 
-The C++ code uses the OpenMP library for parallel processing. (*So, be aware that a large job will eat up all of your machine's processing power...*)
+Optional Dependencies
+---------------------
 
-For all the platforms below, successful compilation will automatically put a compiled library file in ``<your clone main folder>/dqm/bin``, which is where the DQM Python code expects to find it.
-
-Linux
-^^^^^
-
-Compilation from the command line should be simple. (Tested successfully on Ubuntu 22.04.)
+The core functionality of DQM does not require these packages, but they make working with DQM much easier:
 
 .. code-block:: console
 
-   $ cd <your clone main folder>/cpp
+   $ pip install pydqm[viz]
+
+This installs:
+
+* **jupyterlab** - for working with DQM's example Jupyter notebooks
+* **plotly** - for interactive animated 3D plotting
+* **matplotlib** - for basic plotting
+
+Verifying Installation
+----------------------
+
+To verify that DQM is installed correctly and the compiled library is working:
+
+.. code-block:: python
+
+   import dqm
+   print("DQM version:", dqm.__version__ if hasattr(dqm, '__version__') else "0.1.0")
+   print("Compiled library loaded:", dqm.dqm_lib is not None)
+
+You should see ``Compiled library loaded: True``. If you see ``False``, the compiled library failed to load - please report this as an issue.
+
+----
+
+Development Installation
+------------------------
+
+This section is for contributors or users who want to build DQM from source.
+
+Cloning the Repository
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: console
+
+   $ git clone https://github.com/zanderteller/dqm.git
+   $ cd dqm
+
+Building with CMake (Recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+DQM uses CMake for cross-platform builds. The easiest way to build and install for development:
+
+.. code-block:: console
+
+   $ pip install -e .
+
+This will:
+
+1. Compile the C++ library using CMake
+2. Install DQM in "editable" mode (changes to Python code take effect immediately)
+
+**Prerequisites:**
+
+* A C++ compiler (g++, clang++, or MSVC)
+* CMake 3.17 or later
+* OpenMP (for parallel processing - see platform-specific notes below)
+
+Building with Make (Alternative)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The original Makefile is still available for developers who prefer it:
+
+.. code-block:: console
+
+   $ cd cpp
    $ make all
 
-To be sure everything worked, check for the compiled library in its final location: ``<your clone main folder>/dqm/bin/dqm_python.so``.
+Successful compilation puts the library in ``dqm/bin/``.
 
-Windows
-^^^^^^^
+Platform-Specific Notes
+^^^^^^^^^^^^^^^^^^^^^^^
 
-Use `Visual Studio <https://visualstudio.microsoft.com/>`_. In the Visual Studio application:
+**Linux**
 
-* Open the DQM Visual Studio solution file: ``<your clone main folder>/cpp/dqm_python.sln``.
-* Make sure the Configuration dropdown (in the main toolbar near the top of the window) is set to 'Release' (and *not* 'Debug').
-* From the 'Build' menu, run the 'Build Solution' command.
-
-To be sure everything worked, check for the compiled library in its final location: ``<your clone main folder>/dqm/bin/dqm_python.dll``.
-
-Mac
-^^^
-
-**OpenMP**
-
-Unfortunately, Apple officially parted ways with OpenMP a while back. Solutions are possible, but it may or may not be easy. And remember that the exact solution may depend on which kind of chip you have: Intel or ARM (M).
-
-The following was a successful solution on an M1 Mac:
-
-This `R-Project for Mac <https://mac.r-project.org/openmp/>`_ page has prebuilt OpenMP binaries (for both Intel and ARM). As described on that page, we downloaded the lastest version and moved the prebuilt files to the following locations:
+OpenMP is typically available by default. If not:
 
 .. code-block:: console
 
-   /usr/local/lib/libomp.dylib
-   /usr/local/include/ompt.h
-   /usr/local/include/omp.h
-   /usr/local/include/omp-tools.h
+   # Ubuntu/Debian
+   $ sudo apt-get install libgomp1
 
-Note that the DQM Makefile (``<your clone main folder>/cpp/Makefile``) expects to find the above files in those exact locations.
+   # CentOS/RHEL
+   $ sudo yum install libgomp
 
-**g++ Compiler**
+**macOS**
 
-The DQM Makefile expects to use the g++ compiler, which you may need to install (via XCode, homebrew, or other means).
-
-You're welcome to try other compilers as well (we certainly didn't test every option), by changing the line ``CXX:=g++`` in the Makefile.
-
-**Compiling**
-
-Once you've cleared those hurdles, compilation from the command line should be simple:
+Apple does not ship OpenMP by default. Install it via Homebrew:
 
 .. code-block:: console
 
-   $ cd <your clone main folder>/cpp
-   $ make all
+   $ brew install libomp
 
-To be sure everything worked, check for the compiled library in its final location: ``<your clone main folder>/dqm/bin/dqm_python.dylib``.
+The build system automatically detects Homebrew's libomp location on both Intel and Apple Silicon Macs.
 
-|
+**Windows**
+
+Use Visual Studio. Open the solution file ``cpp/dqm_python.sln``, set configuration to "Release", and build.
+
+Alternatively, CMake with MSVC should work (not extensively tested).
+
+----
+
+Troubleshooting
+---------------
+
+**"Compiled library loaded: False"**
+
+The compiled library failed to load. This can happen if:
+
+* The wheel doesn't include a binary for your platform
+* There's a missing system library (like OpenMP)
+
+Try installing from source (see Development Installation above).
+
+**Import errors on macOS**
+
+If you see errors about ``libomp.dylib`` not found, install OpenMP:
+
+.. code-block:: console
+
+   $ brew install libomp
+
+**Reporting Issues**
+
+Please report installation issues on the DQM GitHub `Issues <https://github.com/zanderteller/dqm/issues>`_ page, or start a discussion on the `Discussions <https://github.com/zanderteller/dqm/discussions>`_ page.

--- a/dqm/__init__.py
+++ b/dqm/__init__.py
@@ -2,6 +2,12 @@ import os
 import platform
 import ctypes
 import numpy as np
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("pydqm")
+except PackageNotFoundError:
+    __version__ = "unknown"  # Package not installed (running from source)
 
 
 def load_dqm_lib(lib_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,48 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["scikit-build-core>=0.5", "numpy"]
+build-backend = "scikit_build_core.build"
 
 [project]
-name = "dqm"
+name = "pydqm"
+version = "0.1.0"
 authors = [{name = "Zander Teller", email = "zander.teller@gmail.com"}]
 description = "Dynamic Quantum Mapping"
-version = "0.1.0"
-dependencies = ["numpy"]
+readme = "README.rst"
 license = {file = "LICENSE.txt"}
+requires-python = ">=3.9"
+dependencies = ["numpy"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: C++",
+    "Topic :: Scientific/Engineering",
+]
+keywords = ["dimensionality reduction", "visualization", "animation", "data science"]
 
-[tool.setuptools]
-packages = ["dqm"]
+[project.urls]
+Homepage = "https://github.com/zanderteller/dqm"
+Documentation = "https://dqm.readthedocs.io"
+Repository = "https://github.com/zanderteller/dqm"
+Issues = "https://github.com/zanderteller/dqm/issues"
+Changelog = "https://github.com/zanderteller/dqm/releases"
 
-[tool.setuptools.package-data]
-dqm = ["bin/dqm_python.*"]
+[project.optional-dependencies]
+viz = ["jupyterlab", "plotly", "matplotlib"]
+dev = ["pytest", "ruff"]
+
+[tool.scikit-build]
+cmake.source-dir = "cpp"
+cmake.build-type = "Release"
+wheel.install-dir = "."
+wheel.packages = ["dqm"]
+
+[tool.scikit-build.cmake.define]
+CMAKE_OSX_DEPLOYMENT_TARGET = "10.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: C++",
     "Topic :: Scientific/Engineering",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{name = "Zander Teller", email = "zander.teller@gmail.com"}]
 description = "Dynamic Quantum Mapping"
 readme = "README.rst"
 license = {file = "LICENSE.txt"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["numpy"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -18,7 +18,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -45,4 +44,4 @@ wheel.install-dir = "."
 wheel.packages = ["dqm"]
 
 [tool.scikit-build.cmake.define]
-CMAKE_OSX_DEPLOYMENT_TARGET = "10.13"
+CMAKE_OSX_DEPLOYMENT_TARGET = "11.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pydqm"
-version = "0.1.0"
+version = "0.1.2"
 authors = [{name = "Zander Teller", email = "zander.teller@gmail.com"}]
 description = "Dynamic Quantum Mapping"
 readme = "README.rst"


### PR DESCRIPTION
## Summary

Enable standard `pip install pydqm` via PyPI with pre-built binary wheels.

### Changes

- **Build system**: Add scikit-build-core + CMake for C++ compilation during pip install
- **CI/CD**: GitHub Actions workflows for building wheels (cibuildwheel) and publishing to PyPI
- **Package name**: `pydqm` on PyPI (imports as `dqm`) - the name `dqm` was already taken
- **Supported platforms**: Linux x86_64, macOS Apple Silicon (arm64)
- **Python versions**: 3.10, 3.11, 3.12, 3.13

### Files

- `cpp/CMakeLists.txt` - CMake build configuration
- `pyproject.toml` - scikit-build-core backend, PyPI metadata
- `cpp/Makefile` - Updated to auto-detect Homebrew libomp on macOS
- `.github/workflows/build-wheels.yml` - cibuildwheel CI
- `.github/workflows/publish.yml` - PyPI trusted publishing
- `docs/installation.rst` - Rewritten for pip install
- `README.rst` - Added installation section
- `dqm/__init__.py` - Added `__version__`
- `.gitignore` - Added `dist/`

### Notes

- macOS users need `brew install libomp` (OpenMP not bundled in wheel)
- Intel Mac and Windows users can build from source (documented)
- After merge, create release `v0.1.0` to trigger PyPI publish

## Test plan

- [x] Local wheel build and install works
- [x] CI builds pass (Linux + macOS)
- [x] All 24 unit tests pass on CI
- [x] Manual test of downloaded wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)